### PR TITLE
add username to init command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # API Changes
 
+## 1.1.1
+- For the `init` command, optionally specify the `username` if the API key
+  requires it.
+
 ## 1.1
 
 - For the `cv` command, if the supplied parameter is not formatted properly or we cannot return all the changes from that cursor, the response will now be `cv:?`. Previously, the server responded with `c:?`

--- a/SYNCING.md
+++ b/SYNCING.md
@@ -67,6 +67,7 @@ When a client is ready to connet to a user's bucket it sends the `init` command.
 - **clientid** : a string that identifies the simperium client. Example: **simperium-andriod-1.0**
 - **api** : the api version to use. Current: **1.1**
 - **token** : a user's access token obtained via the auth api.
+- **username** : username used with the auth api
 - **app_id** : a simperium app id. Example: **abusers-headset-123**
 - **name** : the name of the bucket to use. Example: **notes**
 - **library** : the library name of the connecting client: **simperium-android**
@@ -78,7 +79,7 @@ Optionally, the init request can contain a command to be executed upon initializ
 
 An example `init` command with a channel prefix `0`:
 
-    0:init:{"api":1,"client_id":"android-1.0","token":"abc123","app_id":"abusers-headset","name":"notes"}
+    0:init:{"api":1,"client_id":"android-1.0","token":"abc123","username":"jorge@test.com","app_id":"abusers-headset","name":"notes"}
 
 The Simperium server will respond with an `auth` command which will also contain either the authorized user's email address, or if authorization failed, a JSON error object.
 


### PR DESCRIPTION
Would like to add `username` to init command, this would for now be optional (depending on properties of the API key) and all existing clients will continue to work, but the intention will be that all future clients will always send username and token (regardless of whether or not it is necessary)
